### PR TITLE
Remove evil-magit

### DIFF
--- a/config.org
+++ b/config.org
@@ -302,10 +302,6 @@ selection etc.)
     :diminish
     :config (evil-commentary-mode +1))
 #+END_SRC
-Evil keybindings for magit.
-#+BEGIN_SRC emacs-lisp
-  (use-package evil-magit)
-#+END_SRC
 ** Git Integration
 Tell magit to automatically put us in vi-insert-mode when committing a change.
 #+BEGIN_SRC emacs-lisp


### PR DESCRIPTION
Thanks for making this repo, it has been very helpful getting me setup with Emacs!

`evil-magit` is now included in `evil-collection` and it has been removed from melpa so it gives an error when trying to download it.